### PR TITLE
Add husband lifepaths

### DIFF
--- a/src/data/gold/lifepaths/man.json
+++ b/src/data/gold/lifepaths/man.json
@@ -679,16 +679,11 @@
       ],
       "skills": [
         [
-          2,
+          ["+plus_div_husband", 2, 2],
           "Child Rearing",
           "Cooking"
-        ],
-        [
-          "*",
-          "General"
         ]
       ],
-      "skills_expr": ["+plus_div_husband", 0, 2],
       "traits": [
         1
       ],
@@ -2390,16 +2385,15 @@
       ],
       "skills": [
         [
-          2,
+          ["+plus_div_husband", 2, 2],
           "Child Rearing",
           "Cooking"
         ],
         [
-          "*",
+          ["+plus_div_husband", 0, 2],
           "General"
         ]
       ],
-      "skills_expr": ["+plus_div_husband", 0, 2],
       "traits": [
         1
       ],
@@ -5088,16 +5082,11 @@
       ],
       "skills": [
         [
-          2,
+          ["+plus_div_husband", 2, 2],
           "Child Rearing",
           "Husband-wise"
-        ],
-        [
-          "*",
-          "General"
         ]
       ],
-      "skills_expr": ["+plus_div_husband", 0, 2],
       "traits": [
         1
       ],
@@ -7553,13 +7542,9 @@
       ],
       "skills": [
         [
-          "*",
+          ["+mult_time", 1],
           "General"
         ]
-      ],
-      "skills_expr": [
-        "+mult_time",
-        1
       ],
       "traits": [
         1

--- a/src/data/gold/lifepaths/man.json
+++ b/src/data/gold/lifepaths/man.json
@@ -662,7 +662,8 @@
     },
     "Country Wife": {
       "time": 10,
-      "res": 5,
+      "res": "*",
+      "res_expr": ["+plus_div_husband", 5, 2],
       "stat": [
         [
           1,
@@ -681,8 +682,13 @@
           2,
           "Child Rearing",
           "Cooking"
+        ],
+        [
+          "*",
+          "General"
         ]
       ],
+      "skills_expr": ["+plus_div_husband", 0, 2],
       "traits": [
         1
       ],
@@ -2365,7 +2371,8 @@
     },
     "Village Wife": {
       "time": 8,
-      "res": 5,
+      "res": "*",
+      "res_expr": ["+plus_div_husband", 5, 2],
       "stat": [
         [
           1,
@@ -2386,8 +2393,13 @@
           2,
           "Child Rearing",
           "Cooking"
+        ],
+        [
+          "*",
+          "General"
         ]
       ],
+      "skills_expr": ["+plus_div_husband", 0, 2],
       "traits": [
         1
       ],
@@ -5063,7 +5075,8 @@
     },
     "City Wife": {
       "time": 6,
-      "res": 5,
+      "res": "*",
+      "res_expr": ["+plus_div_husband", 5, 4],
       "stat": [
         [
           1,
@@ -5078,8 +5091,13 @@
           2,
           "Child Rearing",
           "Husband-wise"
+        ],
+        [
+          "*",
+          "General"
         ]
       ],
+      "skills_expr": ["+plus_div_husband", 0, 2],
       "traits": [
         1
       ],

--- a/src/public/js/burning-classes.js
+++ b/src/public/js/burning-classes.js
@@ -169,6 +169,7 @@ function DisplayLifepath(setting, name, jsonLifepath){
           this.lifepathSkillPts += skillsCategory[0];
         }
         this.skills = this.skills.concat(skillsCategory.slice(1));
+        initialSkills = this.skills;
       }
     }
   }
@@ -246,10 +247,22 @@ function DisplayLifepath(setting, name, jsonLifepath){
     return s;
   }
   
+  this.isWife = function() {
+    if (this.isWifeCached !== undefined) {
+      return this.isWifeCached;
+    }
+    this.isWifeCached = this.note?.includes?.("husband's lifepath") ?? false;
+    return this.isWifeCached;
+  }
+  
+  this.updateHusbandLifepath = function(burningData) {
+    this.setHusbandLifepath(this.husbandLifepath, burningData.lifepaths.man[setting][this.husbandLifepath]);
+  }
+ 
   this.setHusbandLifepath = function(husbandLpName, jsonHusbandLifepath) {
+    this.skills = initialSkills;
     this.husbandLifepath = husbandLpName;
     if (jsonHusbandLifepath.res == '*'){
-      var oldInnerCalculateResourcePoints = this.innerCalculateResourcePoints.bind(this);
       // Figure out the resource point calculation 
       var resExpr = jsonHusbandLifepath.res_expr
       if ( null == resExpr ){
@@ -259,22 +272,20 @@ function DisplayLifepath(setting, name, jsonLifepath){
       else if( resExpr[0] == '+mult_time'){
         this.resourcePtsIsCalculated = true;
         var mult = parseInt(resExpr[1])
-        this.innerCalculateResourcePoints = function(prevLifepath){
+        this.calculateHusbandResourcePoints = function(prevLifepath){
           this.husbandResourcePts = this.time * mult;
-          oldInnerCalculateResourcePoints(prevLifepath)
         }
       }
       else if( resExpr[0] == '+mult_prev'){
         this.resourcePtsIsCalculated = true;
         var mult = resExpr[1];
-        this.innerCalculateResourcePoints = function(prevLifepath){
+        this.calculateHusbandResourcePoints = function(prevLifepath){
           if(prevLifepath){
             this.husbandResourcePts = Math.floor(prevLifepath.resourcePts * mult);
           }
           else {
             this.husbandResourcePts = -1;
           }
-          oldInnerCalculateResourcePoints(prevLifepath);
         }
       }
       else {
@@ -301,10 +312,8 @@ function DisplayLifepath(setting, name, jsonLifepath){
           if( generalExpr[0] == '+mult_time'){
             this.generalSkillPtsIsCalculated = true;
             var multGenSkill = parseInt(generalExpr[1])
-            var oldInnerCalculateGeneralSkillPoints = this.innerCalculateGeneralSkillPoints.bind(this);
-            this.innerCalculateGeneralSkillPoints = function(){
+            this.calculateHusbandGeneralSkillPoints = function(){
               this.husbandGeneralSkillPts += this.time * multGenSkill;
-              oldInnerCalculateGeneralSkillPoints();
             }
           }
           else {
@@ -324,12 +333,14 @@ function DisplayLifepath(setting, name, jsonLifepath){
   }
 
   this.calculateResourcePoints = function(prevLifepath){
+    this.calculateHusbandResourcePoints?.(prevLifepath);
     if(this.resourcePtsIsCalculated){
       this.innerCalculateResourcePoints(prevLifepath);
     }
   }
 
   this.calculateSkillPoints = function(){
+    this.calculateHusbandGeneralSkillPoints?.();
     if(this.generalSkillPtsIsCalculated){
       this.innerCalculateGeneralSkillPoints();
     }

--- a/src/public/js/burning-modal.js
+++ b/src/public/js/burning-modal.js
@@ -48,13 +48,10 @@ function WeaponOfChoiceModalCtrl($scope, $modalInstance, lifepathName) {
 }
 
 // For use with the angular ui bootstrap Modal call
-function HusbandLifepathModalCtrl($scope, $modalInstance, burningData, setting, lifepathName) {
-  $scope.chosen = [husbandLifepathNames(burningData, setting)[0]];
-  $scope.lifepathName = lifepathName;
-
-  $scope.husbandLifepathNames = function(){
-    return husbandLifepathNames(burningData, setting);
-  }
+function HusbandLifepathModalCtrl($scope, $modalInstance, husbandLifepaths, note) {
+  $scope.husbandLifepathNames = husbandLifepaths;
+  $scope.chosen = [$scope.husbandLifepathNames[0]];
+  $scope.note = note;
 
   $scope.ok = function(){
     $modalInstance.close($scope.chosen[0]);

--- a/src/public/js/burning-modal.js
+++ b/src/public/js/burning-modal.js
@@ -48,6 +48,25 @@ function WeaponOfChoiceModalCtrl($scope, $modalInstance, lifepathName) {
 }
 
 // For use with the angular ui bootstrap Modal call
+function HusbandLifepathModalCtrl($scope, $modalInstance, burningData, setting, lifepathName) {
+  $scope.chosen = [husbandLifepathNames(burningData, setting)[0]];
+  $scope.lifepathName = lifepathName;
+
+  $scope.husbandLifepathNames = function(){
+    return husbandLifepathNames(burningData, setting);
+  }
+
+  $scope.ok = function(){
+    $modalInstance.close($scope.chosen[0]);
+  }
+
+  $scope.cancel = function () {
+    $modalInstance.dismiss('cancel');
+  };
+
+}
+
+// For use with the angular ui bootstrap Modal call
 function EmotionalAttributeModalCtrl($scope, $modalInstance, attributeName, questions, displayEmotionalMath) {
   $scope.attributeName = attributeName;
 

--- a/src/public/js/burning-serialize.js
+++ b/src/public/js/burning-serialize.js
@@ -21,6 +21,7 @@ function loadCurrentCharacterFromStruct($scope, charStruct, burningData, appropr
       // lp[5] is the replacement skill for 'Weapon Of Choice' if it's present.
       // lp[6] is the replacement stat array, if present. This is needed if the
       //       lifepath had a stat penalty.
+      // lp[7] is the husband's lifepath, if present.
 
       var setting = burningData.lifepaths[$scope.stock][lp[0]];
       if (!setting)
@@ -40,6 +41,9 @@ function loadCurrentCharacterFromStruct($scope, charStruct, burningData, appropr
 
       if (lp[6] != null)
         displayLp.stat = lp[6]
+      
+      if (lp[7] != null)
+        displayLp.setHusbandLifepath(lp[7], burningData.lifepaths.man[setting][lp[7]]);
 
       var prevLifepath = null;
       if(selectedLifepaths.length > 0)
@@ -213,8 +217,14 @@ function convertCurrentCharacterToStruct($scope, appropriateWeapons) {
     } else {
       lp.push(null);
     }
-
+    
     lp[6] = displayLp.stat;
+
+    if ( displayLp.husbandLifepath ){
+      lp.push(displayLp.husbandLifepath);
+    } else {
+      lp.push(null)
+    }
 
     lifepaths.push(lp);
   }

--- a/src/public/js/burning-service.js
+++ b/src/public/js/burning-service.js
@@ -208,6 +208,56 @@ function WeaponOfChoiceService($modal, $http) {
 
 /**** End Class WeaponOfChoiceService ****/
 
+/**** Class HusbandLifepathService (Angular Service) ****/
+function HusbandLifepathService($modal, $http, burningData) {
+  this.hasHusbandLifepath = function (displayLp){
+    return displayLp.note?.includes?.("husband's lifepath");
+  }
+ 
+  this.selectHusbandLifepath = function (displayLp, onSelect){
+    if( this.hasHusbandLifepath(displayLp) ){
+      this.selectHusbandLifepathByModal(displayLp.setting, displayLp.name, function(selected){
+        displayLp.setHusbandLifepath(selected, burningData.lifepaths.man[displayLp.setting][selected]);
+
+        if ( onSelect ){
+          onSelect();
+        }
+      })
+    }
+  }
+
+  this.selectHusbandLifepathByModal = function (setting, lifepathName, onSelect){
+    var modalInstance = $modal.open({
+      templateUrl: '/choose_husband_lifepath_partial',
+      controller: HusbandLifepathModalCtrl,
+      resolve: {
+        husbandLifepaths: function() {
+          husbandLifepathNames(burningData, setting);
+        },
+        burningData: function() {
+          return burningData;
+        },
+        lifepathName: function () {
+          return lifepathName;
+        },
+        setting: function() {
+          return setting;
+        }
+      }
+    });
+
+    modalInstance.result.then(function (selected) {
+      console.log("Modal: User selected:");
+      console.log(selected);
+      if ( onSelect ){
+        onSelect(selected);
+      }
+    }, function () {
+      console.log("Modal: User cancelled");
+    });
+  }
+}
+
 /**** Class CharacterStorageService ****/
 function CharacterStorageService($http) {
   this.currentCharacter = null;

--- a/src/public/js/burning-service.js
+++ b/src/public/js/burning-service.js
@@ -216,7 +216,7 @@ function HusbandLifepathService($modal, $http, burningData) {
  
   this.selectHusbandLifepath = function (displayLp, onSelect){
     if( this.hasHusbandLifepath(displayLp) ){
-      this.selectHusbandLifepathByModal(displayLp.setting, displayLp.name, function(selected){
+      this.selectHusbandLifepathByModal(displayLp, function(selected){
         displayLp.setHusbandLifepath(selected, burningData.lifepaths.man[displayLp.setting][selected]);
 
         if ( onSelect ){
@@ -226,22 +226,16 @@ function HusbandLifepathService($modal, $http, burningData) {
     }
   }
 
-  this.selectHusbandLifepathByModal = function (setting, lifepathName, onSelect){
+  this.selectHusbandLifepathByModal = function (displayLp, onSelect){
     var modalInstance = $modal.open({
       templateUrl: '/choose_husband_lifepath_partial',
       controller: HusbandLifepathModalCtrl,
       resolve: {
         husbandLifepaths: function() {
-          husbandLifepathNames(burningData, setting);
+          return husbandLifepathNames(burningData, displayLp.setting);
         },
-        burningData: function() {
-          return burningData;
-        },
-        lifepathName: function () {
-          return lifepathName;
-        },
-        setting: function() {
-          return setting;
+        note: function () {
+          return displayLp.note;
         }
       }
     });

--- a/src/public/js/burning.js
+++ b/src/public/js/burning.js
@@ -54,6 +54,7 @@ burningModule.service('appropriateWeapons', AppropriateWeaponsService);
 burningModule.service('characterStorage', CharacterStorageService);
 burningModule.service('burningData', BurningDataService);
 burningModule.service('weaponOfChoice', WeaponOfChoiceService);
+burningModule.service('husbandLifepath', HusbandLifepathService);
 
 /* Set up URL routes. Different URLs map to different HTML fragments (templates)*/
 burningModule.config(function($routeProvider) {
@@ -77,7 +78,7 @@ burningModule.run(function($rootScope, $location, $anchorScroll, $routeParams) {
   });
 });
 
-function BurningCtrl($scope, $http, $modal, $timeout, settings, appropriateWeapons, weaponOfChoice, characterStorage, burningData){
+function BurningCtrl($scope, $http, $modal, $timeout, settings, appropriateWeapons, weaponOfChoice, husbandLifepath, characterStorage, burningData){
 
   $scope.basicAttributeNames =  ["Mortal Wound", "Reflexes", "Health", "Steel", "Hesitation", "Stride", "Circles", "Resources"];
 
@@ -464,6 +465,14 @@ function BurningCtrl($scope, $http, $modal, $timeout, settings, appropriateWeapo
       else {
         appropriateWeapons.replaceAppropriateWeapons(displayLp, appropriate);
       }
+    }
+
+    // If the lifepath is a Wife lifepath, ask the user to choose the husband's lifepath.
+    if( husbandLifepath.hasHusbandLifepath(displayLp) ){
+      husbandLifepath.selectHusbandLifepath(displayLp, function(){
+        $scope.addDisplayLifepath(displayLp);
+      });
+      return;
     }
 
     // If the lifepath contains 'Weapon Of Choice', ask the 
@@ -1993,6 +2002,10 @@ function isBornLifepath(lifepathName) {
          lifepathName == "Gifted Child";
 }
 
+function isWifeLifepath(lifepathName) {
+  return lifepathName.includes('Wife');
+}
+
 
 function calculateCurrentSettingLifepathNames($scope, burningData){
   var currentSettingLifepathNames = null;
@@ -2597,6 +2610,21 @@ function areLifepathRequirementsSatisfied($scope, rexpr){
 
 function weaponSkillsNames(){
   return ["Axe", "Bow", "Cudgel", "Crossbow", "Firearms", "Firebombs", "Hammer", "Knives", "Lance", "Mace", "Polearm", "Spear", "Staff", "Sword"]
+}
+
+function husbandLifepathNames(burningData, setting){ 
+  var husbandLifepathNamesResult = [];
+  var lifepathNames = Object.keys(burningData.lifepaths.man[setting])
+  for(var j = 0; j < lifepathNames.length; j++){
+    var lifepathName = lifepathNames[j];
+
+    if ( isBornLifepath(lifepathName) || isWifeLifepath(lifepathName) )
+      continue;
+
+    // assume the husband meets any requirements.
+    husbandLifepathNamesResult.push(lifepathName);
+  }
+  return husbandLifepathNamesResult;
 }
 
 // Perform some simple validation on the char struct to ensure it seems mostly legit.

--- a/src/public/js/burning.js
+++ b/src/public/js/burning.js
@@ -396,7 +396,7 @@ function BurningCtrl($scope, $http, $modal, $timeout, settings, appropriateWeapo
     calculateTotalResourcePoints($scope);
     calculateUnspentResourcePoints($scope);
 
-    lp.calculateGeneralSkillPoints();
+    lp.calculateSkillPoints();
     calculateTotalSkillPoints($scope);
     openRequiredSkills($scope);
     calculateUnspentSkillPoints($scope);
@@ -494,7 +494,7 @@ function BurningCtrl($scope, $http, $modal, $timeout, settings, appropriateWeapo
     if($scope.selectedLifepaths.length > 0)
       prevLifepath = $scope.selectedLifepaths[$scope.selectedLifepaths.length-1];
     displayLp.calculateResourcePoints(prevLifepath);
-    displayLp.calculateGeneralSkillPoints(prevLifepath);
+    displayLp.calculateSkillPoints(prevLifepath);
 
     displayLp.modifyForDiminishingReturns($scope.selectedLifepaths);  
     if($scope.stock == "orc"){

--- a/src/public/js/burning.js
+++ b/src/public/js/burning.js
@@ -403,6 +403,27 @@ function BurningCtrl($scope, $http, $modal, $timeout, settings, appropriateWeapo
     removeLifepathSkillsFromGeneralSkills($scope);
     calculateUnspentSkillPoints($scope);
   }
+  $scope.husbandLifepathNames = function(lp){
+    return husbandLifepathNames(burningData, lp.setting);
+  }
+  $scope.onHusbandLifepathChange = function(lp){
+    // the previous husband lifepath's skills are general again
+    for (const possiblyGeneralSkill of lp.skills) {
+      $scope.addGeneralSkill(possiblyGeneralSkill);
+    }
+
+    lp.updateHusbandLifepath(burningData);
+    lp.calculateResourcePoints(null);
+    calculateTotalResourcePoints($scope);
+    calculateUnspentResourcePoints($scope);
+
+    lp.calculateSkillPoints();
+    calculateTotalSkillPoints($scope);
+    calculateLifepathSkills($scope, burningData, appropriateWeapons);
+    openRequiredSkills($scope);
+    removeLifepathSkillsFromGeneralSkills($scope);
+    calculateUnspentSkillPoints($scope);
+  }
 
   burningData.registerOnAllDatasetsLoaded(function(){
     onLifepathsLoad($scope, burningData);

--- a/src/views/partials/choose_husband_lifepath.erb
+++ b/src/views/partials/choose_husband_lifepath.erb
@@ -1,0 +1,16 @@
+<div class='modal-header'>
+  <h3 class='modal-title'>Choose Husband's Lifepath</h3>
+</div>
+<div class='modal-body'>
+  <p>
+    The lifepath '{{lifepathName}}' requires choosing the husband's lifepath.
+  </p>
+  <p>
+    Please choose the husband's lifepath:
+  </p>
+  <select ng-model='chosen[0]' ng-options='i for i in husbandLifepathNames()'></select>
+</div>
+<div class='modal-footer'>
+  <button class='btn btn-primary' ng-click='ok()'>OK</button>
+  <button class='btn btn-warning' ng-click='cancel()'>Cancel</button>
+</div>

--- a/src/views/partials/choose_husband_lifepath.erb
+++ b/src/views/partials/choose_husband_lifepath.erb
@@ -3,12 +3,12 @@
 </div>
 <div class='modal-body'>
   <p>
-    The lifepath '{{lifepathName}}' requires choosing the husband's lifepath.
+    {{note}}
   </p>
   <p>
     Please choose the husband's lifepath:
   </p>
-  <select ng-model='chosen[0]' ng-options='i for i in husbandLifepathNames()'></select>
+  <select ng-model='chosen[0]' ng-options='i for i in husbandLifepathNames'></select>
 </div>
 <div class='modal-footer'>
   <button class='btn btn-primary' ng-click='ok()'>OK</button>

--- a/src/views/partials/main.erb
+++ b/src/views/partials/main.erb
@@ -189,11 +189,16 @@
                   {{lp.note}}
                 </div>
               </div>
-              <div class='row' ng-show='lp.husbandLifepath'>
+              <div class='row' ng-show='lp.isWife()'>
                 <div class='col-md-1'></div>
                 <div class='col-md-7'>
                   <strong>Husband's Lifepath:</strong>
-                  {{lp.husbandLifepath}}
+                  <select class="form-control"
+                    style="width:16em;"
+                    ng-change="onHusbandLifepathChange(lp)"
+                    ng-model="lp.husbandLifepath"
+                    ng-options="h for h in lp.isWife() ? husbandLifepathNames(lp) : []">
+                  </select>
                 </div>
               </div>
               <div class='row' ng-show="stock == 'orc' &amp;&amp; lp.brutalLifeDOF != 0">

--- a/src/views/partials/main.erb
+++ b/src/views/partials/main.erb
@@ -189,6 +189,13 @@
                   {{lp.note}}
                 </div>
               </div>
+              <div class='row' ng-show='lp.husbandLifepath'>
+                <div class='col-md-1'></div>
+                <div class='col-md-7'>
+                  <strong>Husband's Lifepath:</strong>
+                  {{lp.husbandLifepath}}
+                </div>
+              </div>
               <div class='row' ng-show="stock == 'orc' &amp;&amp; lp.brutalLifeDOF != 0">
                 <div class='col-md-1'></div>
                 <div class='col-md-7'>


### PR DESCRIPTION
This pull request implements choosing the husband's lifepath for the three Wife lifepaths.

The user selects the husband's lifepath using a modal similar to the Weapon of Choice modal.

The husband's skill list is concatenated onto the wife's.
The wife's resources and skill points are calculated according to the new ["+plus_div_husband", base, denominator] expression.