### PR TITLE
Fix: 0-lifepaths Man dropdown shows College of Magic and Death Cult

### DIFF
--- a/src/data/gold/lifepaths/man.json
+++ b/src/data/gold/lifepaths/man.json
@@ -7617,7 +7617,7 @@
         "Outcast Subsetting"
       ]
     },
-    "Ditch Digging": {
+    "Ditch Digger": {
       "time": 4,
       "res": 4,
       "leads": [
@@ -7627,7 +7627,7 @@
       "skills": [
         [
           3,
-          "Ditch Digger",
+          "Ditch Digging",
           "Sing",
           "Boss-wise"
         ]

--- a/src/data/gold/lifepaths/man.json
+++ b/src/data/gold/lifepaths/man.json
@@ -7627,7 +7627,7 @@
       "skills": [
         [
           3,
-          "Ditch Digging",
+          "Ditch Digger",
           "Sing",
           "Boss-wise"
         ]

--- a/src/data/wizard/lifepaths.json
+++ b/src/data/wizard/lifepaths.json
@@ -442,7 +442,7 @@
       ]
     }
   },
-  "College of Magic Setting": {
+  "College of Magic Subsetting": {
     "Supplicant": {
       "time": 1,
       "res": 3,
@@ -875,7 +875,7 @@
       ]
     }
   },
-  "Death Cult Setting": {
+  "Death Cult Subsetting": {
     "Harem Slave": {
       "time": 3,
       "res": 3,

--- a/src/lib/data/wizard.rb
+++ b/src/lib/data/wizard.rb
@@ -16,8 +16,8 @@ module Charred
 
       man = data[:lifepaths]['man']
 
-      man['College of Magic Setting'] = wizard_data['College of Magic Setting']
-      man['Death Cult Setting'] = wizard_data['Death Cult Setting']
+      man['College of Magic Subsetting'] = wizard_data['College of Magic Subsetting']
+      man['Death Cult Subsetting'] = wizard_data['Death Cult Subsetting']
 
       data[:lifepaths]['orc']['Servant Of The Dark Blood Subsetting'].merge!(wizard_data['Servant Of The Dark Blood Subsetting'])
 
@@ -55,8 +55,8 @@ module Charred
       end
 
       leads_short = {
-        'College of Magic Setting' => 'College',
-        'Death Cult Setting' => 'Death',
+        'College of Magic Subsetting' => 'College',
+        'Death Cult Subsetting' => 'Death',
       }
       
       # backfill leads

--- a/src/lib/data/wizard.rb
+++ b/src/lib/data/wizard.rb
@@ -59,7 +59,7 @@ module Charred
         'Death Cult Subsetting' => 'Death',
       }
       
-      # backfill leads
+      # backfill leads from requirements
       leads_short.keys.each do |wiz_set|
         wizard_data[wiz_set].keys.each do |wiz_lp|
           lifepath = wizard_data[wiz_set][wiz_lp]
@@ -87,6 +87,24 @@ module Charred
           end
         end
       end
+      
+      # backfill general Death leads
+      # Codex p. 406: "Also, Harem Slave, Captive of War, Gaol, Grave Digger, Pillager, Cripple, Deranged, Leper and Insurrectionist all lead to this setting"
+      # Insurrectionist, Deranged, and Gravedigger are already covered by the requirements backfill
+      man['Servitude And Captive Setting']['Harem Slave']['leads'].push("Death")
+      man['Servitude And Captive Setting']['Harem Slave']['key_leads'].push("Death Cult Subsetting")
+      man['Servitude And Captive Setting']['Captive Of War']['leads'].push("Death")
+      man['Servitude And Captive Setting']['Captive Of War']['key_leads'].push("Death Cult Subsetting")
+      man['Servitude And Captive Setting']['Gaol']['leads'].push("Death")
+      man['Servitude And Captive Setting']['Gaol']['key_leads'].push("Death Cult Subsetting")
+      man['Outcast Subsetting']['Pillager']['leads'].push("Death")
+      man['Outcast Subsetting']['Pillager']['key_leads'].push("Death Cult Subsetting")
+      man['Outcast Subsetting']['Cripple (Lame)']['leads'].push("Death")
+      man['Outcast Subsetting']['Cripple (Lame)']['key_leads'].push("Death Cult Subsetting")
+      man['Outcast Subsetting']['Cripple (Missing Limb)']['leads'].push("Death")
+      man['Outcast Subsetting']['Cripple (Missing Limb)']['key_leads'].push("Death Cult Subsetting")
+      man['Outcast Subsetting']['Leper']['leads'].push("Death")
+      man['Outcast Subsetting']['Leper']['key_leads'].push("Death Cult Subsetting")
 
       # backfill Neophyte Sorcerer and Arcane Devotee connections
       man.keys.each do |man_set|

--- a/src/public/js/burning-classes.js
+++ b/src/public/js/burning-classes.js
@@ -668,41 +668,61 @@ function Alert(desc, type){
 
 /**** Class PTGS ****/
 function PTGS() {
-  this.su = 0
-  this.li = 0
-  this.mi = 0
-  this.se = 0
-  this.tr = 0
-  this.mo = 0
+  this.su = {"shade" : "B", "exp" : 0}
+  this.li = {"shade" : "B", "exp" : 0}
+  this.mi = {"shade" : "B", "exp" : 0}
+  this.se = {"shade" : "B", "exp" : 0}
+  this.tr = {"shade" : "B", "exp" : 0}
+  this.mo = {"shade" : "B", "exp" : 0}
 
   this.calculate = function(forte, mortal) {
-    this.su = Math.floor(forte/2)+1
-
+    this.su.exp = Math.floor(forte/2)+1
+	this.mo=mortal
+	
+	
     /* Put Light, Midi, Severe, and Traumatic as far right as possible, then
      * move them backwards to satisfy the constraint that they may only be 
      * as far apart as half forte rounded up.
      */
 
+	if (this.mo.shade == "B")
+		mo_as_B=this.mo.exp
+	else
+		mo_as_B=this.mo.exp+16
+	
     gap = Math.ceil(forte/2)
 
-    var tol = [mortal-4,mortal-3,mortal-2, mortal-1]
+    var tol = [mo_as_B-4,mo_as_B-3,mo_as_B-2, mo_as_B-1]
     for(i = 0; i < 4; i++) {
-      last = this.su
+      last = this.su.exp
       if (i > 0) 
         last = tol[i-1];
 
       if (tol[i] - last > gap)
         tol[i] = last+gap
 
-      if (tol[i] < this.su)
-        tol[i] = this.su;
+      if (tol[i] < this.su.exp)
+        tol[i] = this.su.exp;
     }
     
-    this.li = tol[0]
-    this.mi = tol[1]
-    this.se = tol[2]
-    this.tr = tol[3]
-    this.mo = mortal
+    this.li.exp = tol[0]
+    this.mi.exp = tol[1]
+    this.se.exp = tol[2]
+    this.tr.exp = tol[3]
+    // Graying as needed (it is not possible to make charecters with Gray Midi)
+    if (this.se.exp >= 17) {
+		this.se.shade="G";
+		this.se.exp-= 16;
+	}
+	else
+		this.se.shade="B";
+    
+    if (this.tr.exp >= 17) {
+		this.tr.shade="G";
+		this.tr.exp-= 16;
+	}
+	else
+		this.tr.shade="B";
   }
 }
 /**** End PTGS ****/

--- a/src/public/js/burning.js
+++ b/src/public/js/burning.js
@@ -997,7 +997,7 @@ function BurningCtrl($scope, $http, $modal, $timeout, settings, appropriateWeapo
 
     if( "Mortal Wound" == name ){
       var shadeAndExp;
-      if ( $scope.stock == 'troll' ) {
+      if ( $scope.stock == 'troll' || $scope.stock == 'dwarf') {
         shadeAndExp = computeStatAverage($scope.statsByName, ["Power", "Forte"], true);
       } else {
         shadeAndExp = computeStatAverage($scope.statsByName, ["Power", "Forte"]);

--- a/src/public/js/burning.js
+++ b/src/public/js/burning.js
@@ -729,6 +729,7 @@ function BurningCtrl($scope, $http, $modal, $timeout, settings, appropriateWeapo
     else
       console.log("Error: changing shade of stat failed: unknown shade " + stat.shade);
 
+	calculatePTGS($scope);
   }
 
   $scope.changeAttributeShade = function(attrName){

--- a/src/public/js/burning.js
+++ b/src/public/js/burning.js
@@ -1983,7 +1983,7 @@ function calculateSettingNames($scope, burningData){
 }
 
 function calculatePTGS($scope) {
-  $scope.ptgs.calculate($scope.statsByName['Forte'].exp(), $scope.attribute("Mortal Wound").exp)
+  $scope.ptgs.calculate($scope.statsByName['Forte'].exp(), $scope.attribute("Mortal Wound"))
 }
 
 

--- a/src/views/partials/main.erb
+++ b/src/views/partials/main.erb
@@ -317,12 +317,12 @@
                   <th>Mo</th>
                 </tr>
                 <tr>
-                  <td>B{{ptgs.su}}</td>
-                  <td>B{{ptgs.li}}</td>
-                  <td>B{{ptgs.mi}}</td>
-                  <td>B{{ptgs.se}}</td>
-                  <td>B{{ptgs.tr}}</td>
-                  <td>B{{ptgs.mo}}</td>
+                  <td>{{ptgs.su.shade}}{{ptgs.su.exp}}</td>
+                  <td>{{ptgs.li.shade}}{{ptgs.li.exp}}</td>
+                  <td>{{ptgs.mi.shade}}{{ptgs.mi.exp}}</td>
+                  <td>{{ptgs.se.shade}}{{ptgs.se.exp}}</td>
+                  <td>{{ptgs.tr.shade}}{{ptgs.tr.exp}}</td>
+                  <td>{{ptgs.mo.shade}}{{ptgs.mo.exp}}</td>
                 </tr>
               </table>
             </div>


### PR DESCRIPTION
You use the key "subsetting" to decided which settings contain "born lifepaths" and which don't so it shows those two from the start (not giving any LP options for it)

To be fair the Codex calls Death Cult a Setting and not a Subsetting but I think that's an inconsistency in their notation, not yours

oh, and there's a typo